### PR TITLE
Map super key to in-game alt

### DIFF
--- a/src/mockmechanics/library/keymap.clj
+++ b/src/mockmechanics/library/keymap.clj
@@ -89,8 +89,8 @@
              GLFW/GLFW_KEY_RIGHT_CONTROL           :control
              GLFW/GLFW_KEY_LEFT_ALT                :alt
              GLFW/GLFW_KEY_RIGHT_ALT               :alt
-             GLFW/GLFW_KEY_LEFT_SUPER              nil
-             GLFW/GLFW_KEY_RIGHT_SUPER             nil
+             GLFW/GLFW_KEY_LEFT_SUPER              :alt
+             GLFW/GLFW_KEY_RIGHT_SUPER             :alt
              })
 
 (def shift-keymap {GLFW/GLFW_KEY_APOSTROPHE              "@"


### PR DESCRIPTION
I noticed on my kid's macbook pro the command key wasn't working in lieu of alt, this fixed it, but probably the "right" solution is to map `super` throughout the code. (Or maybe there's something I'm missing.)